### PR TITLE
Migra al uso de MD vars para CSS + Verde Bandera

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -27,11 +27,16 @@
       ----------------------------------------------------------------------------- */
 
    :root {
-     /* Colores principales */
-     --python-green: #4CAF50;
-     --python-green-dark: #45a049;
-     --python-white: #ffffff;
-
+    /* Material Design Variables */
+     --md-primary-fg-color--lighter: #b3d0c6;
+     --md-primary-fg-color--light: #4d927a;
+     --md-primary-fg-color: #006341;
+     --md-primary-fg-color--dark: #004f34;
+     --md-primary-fg-color--darker: #003221;
+     --md-accent-fg-color--light: #4d927a;
+     --md-accent-fg-color: #006341;
+     --md-accent-fg-color--dark: #004f34;
+     --md-accent-bg-color: #ffffff;
      /* Radios y espaciado */
      --button-radius: 3.125rem;
      --card-radius: 0.75rem;
@@ -129,8 +134,8 @@
    }
 
    .action-buttons a:first-child {
+     color: var(--md-accent-bg-color);
      background: var(--md-primary-fg-color);
-     color: var(--python-white);
    }
 
    .action-buttons a:first-child:hover {
@@ -146,7 +151,7 @@
 
    .action-buttons a:last-child:hover {
      background: var(--md-primary-fg-color);
-     color: var(--python-white);
+     color: var(--md-primary-bg-color);
    }
 
    /* Botones estándar del sitio */
@@ -155,8 +160,8 @@
    .btn-primary,
    .participation-card a,
    .year-card a {
-     background: var(--python-green) !important;
-     color: var(--python-white) !important;
+     background: var(--md-accent-fg-color) !important;
+     color: var(--md-accent-bg-color) !important;
      padding: 0.75rem 1.5rem;
      border-radius: var(--button-radius);
      text-decoration: none;
@@ -175,8 +180,8 @@
    .btn-primary:hover,
    .participation-card a:hover,
    .year-card a:hover {
-     background: var(--python-green-dark) !important;
-     color: var(--python-white) !important;
+     background: var(--md-accent-fg-color--dark) !important;
+     color: var(--md-accent-bg-color) !important;
      transform: translateY(-2px);
      box-shadow: var(--md-shadow-z2);
      text-decoration: none;
@@ -186,16 +191,16 @@
    .btn.btn-primary,
    .btn-primary.mt-2,
    .upcoming-btn {
-     background: var(--python-green) !important;
-     color: var(--python-white) !important;
+     background: var(--md-accent-fg-color) !important;
+     color: var(--md-accent-bg-color) !important;
      text-decoration: none !important;
    }
 
    .btn.btn-primary:hover,
    .btn-primary.mt-2:hover,
    .upcoming-btn:hover {
-     background: var(--python-green-dark) !important;
-     color: var(--python-white) !important;
+     background: var(--md-accent-fg-color--dark) !important;
+     color: var(--md-accent-bg-color) !important;
      text-decoration: none !important;
    }
 
@@ -343,7 +348,7 @@
      left: 0;
      right: 0;
      height: 4px;
-     background: linear-gradient(90deg, var(--md-primary-fg-color), var(--python-green));
+     background: linear-gradient(90deg, var(--md-primary-fg-color), var(--md-primary-bg-color));
      opacity: 0;
      transition: var(--transition-base);
    }
@@ -414,7 +419,7 @@
    /* Especialización de tarjetas por tipo */
    .participation-ponente,
    .year-2025 {
-     border-left: 4px solid var(--python-green);
+     border-left: 4px solid var(--md-primary-fg-color);
    }
 
    .participation-voluntario,
@@ -428,7 +433,7 @@
    }
 
    .year-2025:hover {
-     border-left-color: var(--python-green-dark);
+     border-left-color: var(--md-accent-fg-color--dark);
    }
 
    .year-2024:hover {
@@ -716,7 +721,7 @@
 
    .community-card:hover {
      transform: translateY(-5px);
-     border-color: var(--python-green);
+     border-color: var(--md-accent-fg-color);
      box-shadow: 0 8px 25px rgba(76, 175, 80, 0.15);
      text-decoration: none;
      color: var(--md-default-fg-color);
@@ -733,7 +738,7 @@
    }
 
    .community-card:hover img {
-     border-color: var(--python-green);
+     border-color: var(--md-accent-fg-color);
      transform: scale(1.05);
    }
 
@@ -747,12 +752,12 @@
 
    .community-card h4 i {
      margin-right: 0.5rem;
-     color: var(--python-green);
+     color: var(--md-accent-fg-color);
      font-size: 0.9em;
    }
 
    .community-card:hover h4 {
-     color: var(--python-green);
+     color: var(--md-accent-fg-color);
    }
 
    .community-card p {
@@ -953,8 +958,8 @@
    }
 
    .speaker-links a:hover {
-     background: var(--md-primary-fg-color);
-     color: var(--python-white);
+     background: var(--md-accent-fg-color);
+     color: var(--md-accent-bg-color);
    }
 
    /* Descripción de la charla */
@@ -1053,8 +1058,8 @@
      display: inline-flex;
      align-items: center;
      gap: 0.5rem;
-     background: var(--python-green);
-     color: var(--python-white);
+     background: var(--md-accent-fg-color);
+     color: var(--md-accent-bg-color);
      padding: 0.75rem 1.25rem;
      border-radius: var(--button-radius);
      text-decoration: none;
@@ -1065,8 +1070,8 @@
    }
 
    .youtube-btn:hover {
-     background: var(--python-green-dark);
-     color: var(--python-white);
+     background: var(--md-accent-fg-color--dark);
+     color: var(--md-accent-bg-color);
      transform: translateY(-1px);
      box-shadow: var(--md-shadow-z1);
      text-decoration: none;
@@ -1115,7 +1120,7 @@
 
    .community-link:hover {
      transform: translateY(-3px);
-     color: var(--python-white);
+     color: var(--md-accent-bg-color);
      text-decoration: none;
      animation: none;
    }
@@ -1131,7 +1136,7 @@
    }
 
    .community-link:hover i {
-     color: var(--python-white);
+     color: var(--md-accent-bg-color);
      transform: scale(1.1);
    }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,15 +21,15 @@ theme:
   palette:
     # Light mode
     - scheme: default
-      primary: green
-      accent: green
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Cambiar a modo oscuro
     # Dark mode
     - scheme: slate
-      primary: green
-      accent: green
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Cambiar a modo claro


### PR DESCRIPTION
## 📝 Descripción

Este PR es una segmentación de #26, para simplificar la revisión

## 🎯 Tipo de Cambio

- [ ] 🐛 Bug fix (cambio que arregla un problema)
- [ ] ✨ Nueva característica (cambio que agrega funcionalidad)
- [ ] 📚 Mejora de documentación (cambio que mejora la documentación)
- [x] 🎨 Mejora de diseño (cambio que mejora la apariencia)
- [ ] ⚡ Mejora de rendimiento (cambio que mejora el rendimiento)
- [x] 🔧 Refactorización (cambio que no arregla un bug ni agrega una característica)
- [ ] 🧪 Pruebas (cambio que agrega o mejora pruebas)
- [ ] 📅 Nuevo meetup (agregar información de un nuevo meetup)

## 🔗 Issues Relacionados

Relacionado con #29 

## 📋 Cambios Realizados

- Remueve el uso de variables personalizadas como `python-green` en favor de las variables usadas por el tema de `MaterialDesign for MKDocs`
- Reemplaza el Verde default de Material Design por colores obtenidos a partir del Verde Bandera (de la Bandera mexicana) y las tonalidades obtenidas en [Material Color Generator](https://toologi.com/design-color/material-color-generator/)

## 🧪 Pruebas Realizadas

- [ ] Pruebas locales ejecutadas
- [x] Sitio construido correctamente (`mkdocs build`)
- [x] Servidor de desarrollo funciona (`mkdocs serve`)
- [ ] Documentación actualizada (si aplica)
- [x] Pruebas en diferentes navegadores (si aplica)

## 📸 Capturas de Pantalla

Si este PR incluye cambios visuales, incluye capturas de pantalla:

### Antes

<img width="1579" height="1320" alt="image" src="https://github.com/user-attachments/assets/f3057a72-20f6-437a-9e06-1c59eb2c643f" />

### Después

<img width="1534" height="1322" alt="image" src="https://github.com/user-attachments/assets/e100195f-6ebd-4b8f-b8dc-3c3d296f9f3b" />

## 🔍 Checklist

- [x] Mi código sigue las guías de estilo del proyecto
- [x] He realizado una auto-revisión de mi código
- [ ] He comentado mi código, especialmente en áreas difíciles de entender
- [ ] He hecho los cambios correspondientes en la documentación
- [x] Mis cambios no generan nuevos warnings
- [ ] He agregado pruebas que prueban que mi corrección funciona o que mi característica funciona
- [ ] Las pruebas nuevas y existentes pasan localmente con mis cambios
- [ ] Cualquier cambio dependiente ha sido fusionado y publicado en módulos downstream

## 📝 Notas Adicionales

Este es el primero de los PRs que voy a crear para hacer un code cleanup, los pasos están documentados en el PR original, y nos debería ayudar a un segmento más estable donde dependamos mucho menos en reglas personalizadas de CSS + HTML

La intención final es que los documentos se mantengan tan libres de HTML y classes como sea posible, reduciendo también el número de plugins que usamos.

